### PR TITLE
Add proxy usage and make filename optional or directory

### DIFF
--- a/pypdl/main.py
+++ b/pypdl/main.py
@@ -266,7 +266,7 @@ class Downloader:
     def start(
         self,
         url: str,
-        filepath: Optional[str],
+        filepath: Optional[str] = None,
         num_connections: int = 10,
         display: bool = True,
         multithread: bool = True,

--- a/pypdl/main.py
+++ b/pypdl/main.py
@@ -55,7 +55,8 @@ class Downloader:
 
         Parameters:
             url (str): The URL of the file to download.
-            filepath (str): The file path to save the download. If it is directory or None then filepath is appended with file name.
+            filepath (str): The file path to save the download.
+                If it is directory or None then filepath is appended with file name.
             num_connections (int): The number of connections to use for a multi-threaded download.
             display (bool): Whether to display download progress.
             multithread (bool): Whether to use multi-threaded download.
@@ -279,7 +280,8 @@ class Downloader:
 
         Parameters:
             url (str): The download URL.
-            filepath (str): The optional file path to save the download. If it is directory or None then filepath is appended with file name.
+            filepath (str): The optional file path to save the download.
+                If it is directory or None then filepath is appended with file name.
             num_connections (int): The number of connections to use for a multi-threaded download.
             display (bool): Whether to display download progress.
             multithread (bool): Whether to use multi-threaded download.

--- a/pypdl/utls.py
+++ b/pypdl/utls.py
@@ -10,6 +10,15 @@ from requests.structures import CaseInsensitiveDict
 
 
 def get_filename_from_headers(headers: CaseInsensitiveDict[str]):
+    """
+    Extracts desired file name from given Content-Disposition header
+
+    Parameters:
+        headers (dict): headers from requests.head or requests.get response
+
+    Returns:
+        Desired file name
+    """
     content_disposition = headers.get('Content-Disposition')
 
     if content_disposition and 'filename=' in content_disposition:
@@ -20,8 +29,7 @@ def get_filename_from_headers(headers: CaseInsensitiveDict[str]):
         # Decode URL encoding
         filename = unquote(filename)
         return filename
-    else:
-        return None
+    return None
 
 
 def timestring(sec: int) -> str:

--- a/pypdl/utls.py
+++ b/pypdl/utls.py
@@ -3,8 +3,25 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Tuple
+from urllib.parse import unquote
 
 import requests
+from requests.structures import CaseInsensitiveDict
+
+
+def get_filename_from_headers(headers: CaseInsensitiveDict[str]):
+    content_disposition = headers.get('Content-Disposition')
+
+    if content_disposition and 'filename=' in content_disposition:
+        filename_start = content_disposition.index('filename=') + len('filename=')
+        filename = content_disposition[filename_start:]
+        # Remove quotes and any leading or trailing spaces
+        filename = filename.strip(' "')
+        # Decode URL encoding
+        filename = unquote(filename)
+        return filename
+    else:
+        return None
 
 
 def timestring(sec: int) -> str:


### PR DESCRIPTION
Thank you so much for your library, it is very useful for me.
But there are a few things I would like to correct:
1. The name of the downloaded file is often unknown to the user and is obtained via a HEAD request. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
So I thought it would be permissible to make filepath optional or folder, so that the user side doesn't have to do an overhead like another HEAD request. This would then generate the file name with Content-Disposition taken into account.
2. No proxy or authorization was used for the HEAD request, which can cause problems in some cases